### PR TITLE
Ensure files are from Download folder with grep

### DIFF
--- a/downloads-folder-cleaner.applescript
+++ b/downloads-folder-cleaner.applescript
@@ -14,7 +14,7 @@ on run argv
   end if
 
   set downloadFolder to quoted form of (POSIX path of (path to downloads folder))
-  set mdfindQuery to "mdfind -onlyin " & downloadFolder & " 'kMDItemDateAdded<$time.now(-" & deleteIfOrderThan & ")'"
+  set mdfindQuery to "mdfind -onlyin " & downloadFolder & " 'kMDItemDateAdded<$time.now(-" & deleteIfOrderThan & ")' | grep " & downloadFolder
 
   log "Query command: " & mdfindQuery & "\n"
   set filteredFiles to do shell script mdfindQuery


### PR DESCRIPTION
This resolves #4

## Why is this change necessary?

- Encounter `The item "xxx" can't be moved to the Trash because it can't be deleted.` error sometimes

## How does it address the issue?

- Main issue was that the `mdfind -onlyin` option is not reliable.
Add a grep to ensure it's from desired directory

## How it was tested?

- Manually trigger the applescript